### PR TITLE
Add env var definitions for LMS1XX and UR5 IPs

### DIFF
--- a/launch/sick_config/sick.launch
+++ b/launch/sick_config/sick.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
   <node pkg="lms1xx" name="lms1xx" type="LMS1xx_node">
-    <param name="host" value="192.168.1.14" />
+    <param name="host" value="$(env HUSKY_LMS1XX_IP)" />
   </node>
 </launch>

--- a/launch/ur5_arm_config/ur5.launch
+++ b/launch/ur5_arm_config/ur5.launch
@@ -28,7 +28,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <!-- Launches the drivers and sets parameters for the ur5 arm -->
   <!-- Mostly taken from the ur_common.launch inside ur_common.launch -->
 
-  <arg name="robot_ip" default="192.168.0.11"/>
+  <arg name="robot_ip" default="$(env HUSKY_UR5_IP)"/>
   <arg name="reverse_port" default="50001"/>
   <arg name="min_payload"/>
   <arg name="max_payload"/>

--- a/scripts/install
+++ b/scripts/install
@@ -17,4 +17,10 @@ if os.path.exists('/dev/microstrain'):
 if os.path.exists('/dev/clearpath/gps'):
   j.add(package="husky_bringup", glob="launch/navsat_config/*")
 
+if os.environ.get('HUSKY_UR5_IP'):
+  j.add(package="husky_bringup", glob="launch/ur5_arm_config/*")
+
+if os.environ.get('HUSKY_LMS1XX_IP'):
+  j.add(package="husky_bringup", glob="launch/sick_config/*")
+
 j.install()


### PR DESCRIPTION
If you set

> export HUSKY_UR5_IP='192.168.0.11'

in /etc/ros/setup.bash.. 

> rosrun husky_bringup install 

should autodetect arm and add the launch files. @TheDash, could you please check on hardware that it works as expected?
